### PR TITLE
Fix / Migration script / ts_template_time_savings table not found

### DIFF
--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -67,8 +67,10 @@ exports.up = async function up(knex) {
       );
   }
 
+  await knex.schema
+    .createTable('ts_template_time_savings', (table) => {
       table.comment(
-        'Table contains template time savings with relation to the templateTaskId',
+        'Table contains template time savings with relation to the templateTaskId'
       );
 
       if (isPostgreSQL) {
@@ -93,20 +95,49 @@ exports.up = async function up(knex) {
         .notNullable()
         .defaultTo(knex.fn.now())
         .comment('The creation time of the record');
-      table.string('template_task_id').comment('Template task ID');
+
+      table
+      .string('template_task_id')
+      .comment('Template task ID');
+
       table
         .string('template_name')
         .comment('Template name as template entity_reference');
-      table.string('team').comment('Team name of saved time');
+
+      table
+        .string('team')
+        .comment('Team name of saved time');
+
       table
         .float('time_saved', 2)
         .comment('time saved by the team within template task ID, in hours');
-      table.string('template_task_status').comment('template task status');
+
+      table
+      .string('template_task_status')
+      .comment('template task status');
+
       table
         .string('created_by')
-        .comment('entity refernce to the user that has executed the template');
-    });
-  }
+        .comment('entity reference to the user that has executed the template');
+    })
+    .then(
+      (s) => {
+        response = {
+          ...response,
+          ts_template_time_savings: s,
+        };
+        console.log('Created table ts_template_time_savings.');
+      },
+      (reason) => {
+        response = {
+          ...response,
+          ts_template_time_savings: `Not created: ${reason}`,
+        };
+        console.log('Failed to create table ts_template_time_savings.');
+      }
+    );
+
+  return response;
 };
 
 /**
@@ -115,3 +146,4 @@ exports.up = async function up(knex) {
 exports.down = async function down(knex) {
   return knex.schema.dropTable('ts_template_time_savings');
 };
+

--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -20,13 +20,8 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
-  //  create function only for postgres
-  let namespace = '';
-  if (knex.client.config.client === 'pg') {
-    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"').then(() => {
-      console.log('uuid-ossp extension enabled');
-    });
-    namespace = await knex
+  let namespace;
+  let response = {};
       .raw(
         `SELECT (select nspname from pg_catalog.pg_namespace where oid=extnamespace)
     FROM pg_extension where extname='uuid-ossp';`,

--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -22,6 +22,8 @@
 exports.up = async function up(knex) {
   let namespace;
   let response = {};
+  const isPostgreSQL = knex.client.config.client === 'pg';
+
       .raw(
         `SELECT (select nspname from pg_catalog.pg_namespace where oid=extnamespace)
     FROM pg_extension where extname='uuid-ossp';`,

--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -70,11 +70,24 @@ exports.up = async function up(knex) {
       table.comment(
         'Table contains template time savings with relation to the templateTaskId',
       );
-      table
-        .uuid('id')
-        .primary()
-        .defaultTo(knex.raw(`${namespace}.uuid_generate_v4()::uuid`))
-        .comment('UUID');
+
+      if (isPostgreSQL) {
+        if (namespace) {
+          table
+          .uuid('id')
+          .primary()
+          .defaultTo(knex.raw(`${namespace}.uuid_generate_v4()::uuid`))
+          .comment('UUID');
+        } else {
+          console.log("Could not create id column using postgreSQL database.")
+        }
+      } else {
+        table
+          .uuid('id')
+          .primary()
+          .comment('UUID');
+      }
+
       table
         .timestamp('created_at', { useTz: false, precision: 0 })
         .notNullable()

--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -20,7 +20,7 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
-  let namespace;
+  let namespace = '';
   let response = {};
   const isPostgreSQL = knex.client.config.client === 'pg';
 
@@ -74,7 +74,7 @@ exports.up = async function up(knex) {
       );
 
       if (isPostgreSQL) {
-        if (namespace) {
+        if (namespace !== '') {
           table
           .uuid('id')
           .primary()


### PR DESCRIPTION
Provides fix to migration script when attempting to create ts_template_time_savings. Previously, the script would only install the table if using a postgreSQL database.