### PR TITLE
Fix/unecessary base 64 decoding

### DIFF
--- a/plugins/time-saver-backend/package.json
+++ b/plugins/time-saver-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver-backend",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver-backend/src/api/scaffolderClient.ts
+++ b/plugins/time-saver-backend/src/api/scaffolderClient.ts
@@ -52,7 +52,9 @@ export class ScaffolderClient {
   if (keyConfig) {
       key = keyConfig[0].secret
     }
-    const decodedBytes = this.decodeFromBase64(key);
+    const decodedBytes = this.isBase64(key)
+      ? this.decodeFromBase64(key)
+      : key;
     const tokenSub = name ?? 'backstage-server'
 
     const payload = {

--- a/plugins/time-saver-backend/src/api/scaffolderClient.ts
+++ b/plugins/time-saver-backend/src/api/scaffolderClient.ts
@@ -64,6 +64,9 @@ export class ScaffolderClient {
     return encodedJwt
   }
 
+  isBase64(value: string): boolean {
+    return /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{4})$/.test(value);
+  }
   decodeFromBase64(input: string): Buffer {
     return Buffer.from(base64.toByteArray(input));
   }


### PR DESCRIPTION
Provides fix to ScaffolderClient when trying to decode a non-base64 key. Usually, the backsateg is deployed using kubernetes, keys do get encrypted and converted to base64. However, when deploying using yarn dev these aren't, thus making the application crash when trying to decode it.