### PR TITLE
Fix / Migrations / UUID function not available in other databases

### DIFF
--- a/plugins/time-saver-backend/migrations/init.js
+++ b/plugins/time-saver-backend/migrations/init.js
@@ -20,47 +20,116 @@
  * @param {import('knex').Knex} knex
  */
 exports.up = async function up(knex) {
-  //  create function only for postgres
   let namespace = '';
-  if (knex.client.config.client === 'pg') {
-    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"').then(() => {
-      console.log('uuid-ossp extension enabled');
-    });
-    namespace = await knex
+  let response = {};
+  const isPostgreSQL = knex.client.config.client === 'pg';
+
+  // create extension only for postgreSQL
+  if (isPostgreSQL) {
+    await knex.raw('CREATE EXTENSION IF NOT EXISTS "uuid-ossp"').then(
+      () => {
+        response = {
+          ...response,
+          pg_extension: 'enabled',
+        };
+        console.log('uuid-ossp extension enabled');
+      },
+      (reason) => {
+        response = {
+          ...response,
+          pg_extension: `disabled: ${reason}}`,
+        };
+        console.log(`Could not create uuid-ossp extension: ${reason}`);
+      }
+    );
+
+    await knex
       .raw(
         `SELECT (select nspname from pg_catalog.pg_namespace where oid=extnamespace)
-    FROM pg_extension where extname='uuid-ossp';`,
+      FROM pg_extension where extname='uuid-ossp';`
       )
-      .then(s => s.rows[0].nspname);
-    console.log(`uuid-ossp extension created in ${namespace} schema`);
-    await knex.schema.createTable('ts_template_time_savings', table => {
+      .then(
+        (s) => {
+          namespace = s.rows[0].nspname;
+          response = {
+            ...response,
+            namespace,
+          };
+          console.log(`uuid-ossp extension created in ${namespace} schema`);
+        },
+        (reason) => {
+          response = {
+            ...response,
+            namespace: `undefined: ${reason}`,
+          };
+          console.log('uuid-ossp extension was not found.');
+        }
+      );
+  }
+
+  await knex.schema
+    .createTable('ts_template_time_savings', (table) => {
       table.comment(
-        'Table contains template time savings with relation to the templateTaskId',
+        'Table contains template time savings with relation to the templateTaskId'
       );
       table
         .uuid('id')
         .primary()
-        .defaultTo(knex.raw(`${namespace}.uuid_generate_v4()::uuid`))
+        .defaultTo(
+          isPostgreSQL
+          ? knex.raw(`${namespace}.uuid_generate_v4()::uuid`)
+          : knex.fn.uuid()
+        )
         .comment('UUID');
+
       table
         .timestamp('created_at', { useTz: false, precision: 0 })
         .notNullable()
         .defaultTo(knex.fn.now())
         .comment('The creation time of the record');
-      table.string('template_task_id').comment('Template task ID');
+
+      table
+      .string('template_task_id')
+      .comment('Template task ID');
+
       table
         .string('template_name')
         .comment('Template name as template entity_reference');
-      table.string('team').comment('Team name of saved time');
+
+      table
+        .string('team')
+        .comment('Team name of saved time');
+
       table
         .float('time_saved', 2)
         .comment('time saved by the team within template task ID, in hours');
-      table.string('template_task_status').comment('template task status');
+
+      table
+      .string('template_task_status')
+      .comment('template task status');
+
       table
         .string('created_by')
-        .comment('entity refernce to the user that has executed the template');
-    });
-  }
+        .comment('entity reference to the user that has executed the template');
+    })
+    .then(
+      (s) => {
+        response = {
+          ...response,
+          ts_template_time_savings: s,
+        };
+        console.log('Created table ts_template_time_savings.');
+      },
+      (reason) => {
+        response = {
+          ...response,
+          ts_template_time_savings: `Not created: ${reason}`,
+        };
+        console.log('Failed to create table ts_template_time_savings.');
+      }
+    );
+
+  return response;
 };
 
 /**
@@ -69,3 +138,4 @@ exports.up = async function up(knex) {
 exports.down = async function down(knex) {
   return knex.schema.dropTable('ts_template_time_savings');
 };
+

--- a/plugins/time-saver-backend/package.json
+++ b/plugins/time-saver-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver-backend",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver-backend/src/api/scaffolderClient.ts
+++ b/plugins/time-saver-backend/src/api/scaffolderClient.ts
@@ -22,7 +22,7 @@ export class ScaffolderClient {
   constructor(
     private readonly logger: Logger,
     private readonly config: Config,
-  ) {}
+  ) { }
 
   async fetchTemplatesFromScaffolder() {
     let backendUrl =

--- a/plugins/time-saver-backend/src/database/scaffolderDb.ts
+++ b/plugins/time-saver-backend/src/database/scaffolderDb.ts
@@ -34,7 +34,7 @@ export interface DatabaseConfiguration {
 }
 
 export class ScaffolderDb {
-  constructor(private readonly config: Config) {}
+  constructor(private readonly config: Config) { }
 
   private readonly scaffolderDbName = 'backstage_plugin_scaffolder';
 


### PR DESCRIPTION
Provides fix for when using a database other than postrgress. By default, the DB migration script would try to install the uuid-ossp extension and use its UUID generator function to provide the ts_template_time_savings id column with UUID generated values. However, this function is not available in other databases.