### PR TITLE
Feature/service to service auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-timesaver-plugin",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "This plugin provides an implementation of charts and statistics related to your time savings that are coming from usage of your templates.",
   "private": true,
   "engines": {

--- a/plugins/time-saver-backend/README.md
+++ b/plugins/time-saver-backend/README.md
@@ -55,7 +55,7 @@ apiRouter.use('/time-saver', await timeSaver(timeSaverEnv)); // you should use a
 
 ```
 
-3. Generate and specify an static token for communication against the scaffolder using service to service authentication. Please have in mind that the plugin looks for time-saver as the subject.
+3. Generate and specify a static token for communication with the scaffold using service-to-service authentication. This can be retrieved using the subject `time-saver` with the configuration object.
 
 ```yaml
 backend:
@@ -64,7 +64,7 @@ backend:
       ...
       - type: static
         options:
-          token: ${MY_SECRET}
+          token: ${TIME_SAVER_AUTH_TOKEN}
           subject: time-saver
 ```
 

--- a/plugins/time-saver-backend/README.md
+++ b/plugins/time-saver-backend/README.md
@@ -55,6 +55,19 @@ apiRouter.use('/time-saver', await timeSaver(timeSaverEnv)); // you should use a
 
 ```
 
+3. Generate and specify an static token for communication against the scaffolder using service to service authentication. Please have in mind that the plugin looks for time-saver as the subject.
+
+```yaml
+backend:
+  auth:
+    externalAccess:
+      ...
+      - type: static
+        options:
+          token: ${MY_SECRET}
+          subject: time-saver
+```
+
 ### New Backend - instalation
 
 2. Wire up the plugin in Backstage new backend system

--- a/plugins/time-saver-backend/package.json
+++ b/plugins/time-saver-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver-backend",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver-backend/package.json
+++ b/plugins/time-saver-backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver-backend",
-  "version": "0.1.14",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver-backend/src/api/scaffolderClient.ts
+++ b/plugins/time-saver-backend/src/api/scaffolderClient.ts
@@ -61,13 +61,14 @@ export class ScaffolderClient {
   async generateBackendToken(config: Config, name?: string) {
     let key: string = '';
     let decodedBytes: Buffer | string = '';
-    const keyConfig: { type: string, options: {token: string, subject: string}}[] | undefined =
-      config.getOptional('backend.auth.externalAccess');
+    const keyConfig:
+      | { type: string; options: { token: string; subject: string } }[]
+      | undefined = config.getOptional('backend.auth.externalAccess');
 
-    keyConfig?.forEach((item) => {
+    keyConfig?.forEach(item => {
       if (item.options.subject === 'time-saver') {
         key = item.options.token;
-      };
+      }
     });
 
     if (key !== '') {

--- a/plugins/time-saver-backend/src/api/scaffolderClient.ts
+++ b/plugins/time-saver-backend/src/api/scaffolderClient.ts
@@ -61,11 +61,16 @@ export class ScaffolderClient {
   async generateBackendToken(config: Config, name?: string) {
     let key: string = '';
     let decodedBytes: Buffer | string = '';
-    const keyConfig: { secret: string }[] | undefined =
-      config.getOptional('backend.auth.keys');
+    const keyConfig: { type: string, options: {token: string, subject: string}}[] | undefined =
+      config.getOptional('backend.auth.externalAccess');
 
-    if (keyConfig) {
-      key = keyConfig[0].secret;
+    keyConfig?.forEach((item) => {
+      if (item.options.subject === 'time-saver') {
+        key = item.options.token;
+      };
+    });
+
+    if (key !== '') {
       decodedBytes = this.isBase64(key) ? this.decodeFromBase64(key) : key;
     } else {
       decodedBytes = '';

--- a/plugins/time-saver/package.json
+++ b/plugins/time-saver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver",
-  "version": "0.1.9",
+  "version": "1.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver/package.json
+++ b/plugins/time-saver/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tduniec/backstage-plugin-time-saver",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
@@ -53,7 +53,7 @@ export function AllStatsBarChart(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
@@ -24,8 +24,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -41,12 +41,13 @@ type AllStatsChartResponse = {
 
 export function AllStatsBarChart(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<AllStatsChartResponse | null>(null);
   const theme = useTheme();
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString('backend.baseUrl')}/api/time-saver/getStats`,
     )
       .then(response => response.json())

--- a/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/AllStatsBarChartComponent/AllStatsBarChartComponent.tsx
@@ -47,9 +47,10 @@ export function AllStatsBarChart(): React.ReactElement {
   const theme = useTheme();
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString('backend.baseUrl')}/api/time-saver/getStats`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString('backend.baseUrl')}/api/time-saver/getStats`,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
+++ b/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
@@ -24,8 +24,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -48,13 +48,14 @@ export function BarChart({
   templateTaskId,
 }: BarChartProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<SingleTemplateChartResponse | null>(null);
 
   const theme = useTheme();
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString(
         'backend.baseUrl',
       )}/api/time-saver/getStats?templateTaskId=${templateTaskId} `,

--- a/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
+++ b/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
@@ -63,7 +63,7 @@ export function BarChart({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi, templateTaskId]);
+  }, [configApi, templateTaskId, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
+++ b/plugins/time-saver/src/components/BarChartComponent/BarChartComponent.tsx
@@ -55,11 +55,12 @@ export function BarChart({
   const theme = useTheme();
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString(
-        'backend.baseUrl',
-      )}/api/time-saver/getStats?templateTaskId=${templateTaskId} `,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getStats?templateTaskId=${templateTaskId} `,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
@@ -24,8 +24,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -47,13 +47,14 @@ export function ByTeamBarChart({
   team,
 }: ByTeamBarChartProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<TeamChartResponse | null>(null);
 
   const theme = useTheme();
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString(
         'backend.baseUrl',
       )}/api/time-saver/getStats?team=${team} `,

--- a/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
@@ -62,7 +62,7 @@ export function ByTeamBarChart({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi, team]);
+  }, [configApi, team, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTeamBarCharComponent/ByTeamBarChartComponent.tsx
@@ -54,11 +54,12 @@ export function ByTeamBarChart({
   const theme = useTheme();
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString(
-        'backend.baseUrl',
-      )}/api/time-saver/getStats?team=${team} `,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getStats?team=${team} `,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
@@ -60,7 +60,7 @@ export function ByTemplateBarChart({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi, template_name]);
+  }, [configApi, template_name, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
@@ -52,11 +52,12 @@ export function ByTemplateBarChart({
   const theme = useTheme();
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString(
-        'backend.baseUrl',
-      )}/api/time-saver/getStats?templateName=${template_name} `,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getStats?templateName=${template_name} `,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
+++ b/plugins/time-saver/src/components/ByTemplateBarCharComponent/ByTemplateBarChartComponent.tsx
@@ -24,8 +24,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Bar } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -47,11 +47,12 @@ export function ByTemplateBarChart({
   template_name,
 }: ByTemplateBarChartProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] = useState<TemplateChartResponse | null>(null);
   const theme = useTheme();
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString(
         'backend.baseUrl',
       )}/api/time-saver/getStats?templateName=${template_name} `,

--- a/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
+++ b/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
@@ -44,7 +44,7 @@ export function EmptyTimeSaver(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
+++ b/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
@@ -40,7 +40,8 @@ export function EmptyTimeSaver(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/templates`;
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
+++ b/plugins/time-saver/src/components/Gauge/EmptyDbContent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import {
   Table,
@@ -24,7 +24,6 @@ import {
   TableContainer,
   TableRow,
 } from '@material-ui/core';
-import { fetchWithCredentials } from '../utils';
 
 type TemplatesResponse = {
   templates: string[];
@@ -32,6 +31,7 @@ type TemplatesResponse = {
 
 export function EmptyTimeSaver(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<TemplatesResponse | null>(null);
 
@@ -40,7 +40,7 @@ export function EmptyTimeSaver(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/templates`;
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Gauge from './Gauge';
-import { fetchWithCredentials } from '../utils';
 
 type GroupsResponse = {
   groups: string[];
@@ -25,6 +24,7 @@ type GroupsResponse = {
 
 export function TeamsGauge(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] = useState<GroupsResponse | null>(null);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function TeamsGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/groups`;
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
@@ -32,7 +32,8 @@ export function TeamsGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/groups`;
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TeamsGauge.tsx
@@ -36,7 +36,7 @@ export function TeamsGauge(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Gauge from './Gauge';
-import { fetchWithCredentials } from '../utils';
 
 type TemplateResponse = {
   templates: string[];
@@ -25,6 +24,7 @@ type TemplateResponse = {
 
 export function TemplatesGauge(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] = useState<TemplateResponse | null>(null);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function TemplatesGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/templates`;
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
@@ -36,7 +36,7 @@ export function TemplatesGauge(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesGauge.tsx
@@ -32,7 +32,8 @@ export function TemplatesGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/templates`;
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Gauge from './Gauge';
-import { fetchWithCredentials } from '../utils';
 
 type TemplateTaskCountResponse = {
   templateTasks: number;
@@ -25,6 +24,7 @@ type TemplateTaskCountResponse = {
 
 export function TemplateCountGauge(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] = useState<TemplateTaskCountResponse | null>(null);
 
   useEffect(() => {
@@ -32,7 +32,7 @@ export function TemplateCountGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/getTemplateCount`;
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
@@ -32,7 +32,8 @@ export function TemplateCountGauge(): React.ReactElement {
       'backend.baseUrl',
     )}/api/time-saver/getTemplateCount`;
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TemplatesTaskCountGauge.tsx
@@ -36,7 +36,7 @@ export function TemplateCountGauge(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
@@ -43,7 +43,8 @@ export function TimeSavedGauge({
       url = `${url}?divider=${number}`;
     }
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
@@ -47,7 +47,7 @@ export function TimeSavedGauge({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi, number]);
+  }, [configApi, number, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
+++ b/plugins/time-saver/src/components/Gauge/TimeSavedGauge.tsx
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Gauge from './Gauge';
-import { fetchWithCredentials } from '../utils';
 
 type TimeSavedResponse = {
   timeSaved: number;
@@ -33,6 +32,7 @@ export function TimeSavedGauge({
   heading,
 }: TimeSavedGaugeProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] = useState<TimeSavedResponse | null>(null);
 
   useEffect(() => {
@@ -43,7 +43,7 @@ export function TimeSavedGauge({
       url = `${url}?divider=${number}`;
     }
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
+++ b/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
@@ -44,9 +44,12 @@ export function GroupDivisionPieChart(): React.ReactElement {
   const theme = useTheme();
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString('backend.baseUrl')}/api/time-saver/getStats/group`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getStats/group`,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
+++ b/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
@@ -22,8 +22,8 @@ import {
   ArcElement,
 } from 'chart.js';
 import { Pie } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -38,12 +38,13 @@ type GroupDivisionPieChartResponse = {
 
 export function GroupDivisionPieChart(): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<GroupDivisionPieChartResponse | null>(null);
   const theme = useTheme();
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString('backend.baseUrl')}/api/time-saver/getStats/group`,
     )
       .then(response => response.json())

--- a/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
+++ b/plugins/time-saver/src/components/GroupDivisionPieChartComponent/GroupDivisionPieChartComponent.tsx
@@ -50,7 +50,7 @@ export function GroupDivisionPieChart(): React.ReactElement {
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Table/StatsTable.tsx
+++ b/plugins/time-saver/src/components/Table/StatsTable.tsx
@@ -16,9 +16,8 @@
 import React, { useState, useEffect } from 'react';
 
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import { DataGrid, GridColDef, GridSortModel } from '@mui/x-data-grid';
-import { fetchWithCredentials } from '../utils';
 import { useTheme, Paper } from '@material-ui/core';
 
 type Stat = {
@@ -45,6 +44,7 @@ const StatsTable: React.FC<StatsTableProps> = ({ team, template_name }) => {
   ]);
 
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const theme = useTheme();
 
@@ -58,7 +58,7 @@ const StatsTable: React.FC<StatsTableProps> = ({ team, template_name }) => {
       url = `${url}?templateName=${template_name}`;
     }
 
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then((dt: AllStatsChartResponse) => {
         const statsWithIds = dt.stats.map((stat, index) => ({

--- a/plugins/time-saver/src/components/Table/StatsTable.tsx
+++ b/plugins/time-saver/src/components/Table/StatsTable.tsx
@@ -69,7 +69,7 @@ const StatsTable: React.FC<StatsTableProps> = ({ team, template_name }) => {
         setSortModel([{ field: 'sum', sort: 'desc' }]);
       })
       .catch();
-  }, [configApi, team, template_name]);
+  }, [configApi, team, template_name, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/Table/StatsTable.tsx
+++ b/plugins/time-saver/src/components/Table/StatsTable.tsx
@@ -58,7 +58,8 @@ const StatsTable: React.FC<StatsTableProps> = ({ team, template_name }) => {
       url = `${url}?templateName=${template_name}`;
     }
 
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then((dt: AllStatsChartResponse) => {
         const statsWithIds = dt.stats.map((stat, index) => ({

--- a/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
+++ b/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
@@ -67,7 +67,7 @@ export default function TeamSelector({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi, onTeamChange]);
+  }, [configApi, onTeamChange, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
+++ b/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import React, { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import {
   Button,
@@ -24,7 +24,6 @@ import {
   InputLabel,
   MenuItem,
 } from '@material-ui/core';
-import { fetchWithCredentials } from '../utils';
 
 interface TeamSelectorProps {
   onTeamChange: (team: string) => void;
@@ -59,9 +58,10 @@ export default function TeamSelector({
 
   const [data, setData] = useState<GroupsResponse | null>(null);
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString('backend.baseUrl')}/api/time-saver/groups`,
     )
       .then(response => response.json())

--- a/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
+++ b/plugins/time-saver/src/components/TeamSelectorComponent/TeamSelectorComponent.tsx
@@ -61,9 +61,8 @@ export default function TeamSelector({
   const fetchApi = useApi(fetchApiRef);
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString('backend.baseUrl')}/api/time-saver/groups`,
-    )
+    fetchApi
+      .fetch(`${configApi.getString('backend.baseUrl')}/api/time-saver/groups`)
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
@@ -53,11 +53,12 @@ export function DailyTimeSummaryLineChartTeamWise({
   const [data, setData] = useState<DailyTimeSummaryResponse | null>(null);
   const theme = useTheme();
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString(
-        'backend.baseUrl',
-      )}/api/time-saver/getDailyTimeSummary/team`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getDailyTimeSummary/team`,
+      )
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
@@ -25,8 +25,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -48,11 +48,12 @@ export function DailyTimeSummaryLineChartTeamWise({
   team,
 }: DailyTimeSummaryLineProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<DailyTimeSummaryResponse | null>(null);
   const theme = useTheme();
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString(
         'backend.baseUrl',
       )}/api/time-saver/getDailyTimeSummary/team`,

--- a/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseDailyTimeLinearComponent/TeamWiseDailyTimeLinearComponent.tsx
@@ -69,7 +69,7 @@ export function DailyTimeSummaryLineChartTeamWise({
         setData(dt);
       })
       .catch();
-  }, [configApi, team]);
+  }, [configApi, team, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
@@ -25,8 +25,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 
 ChartJS.register(LineElement, PointElement, Title, Tooltip, Legend);
 import CircularProgress from '@material-ui/core/CircularProgress';
@@ -48,13 +48,14 @@ export function TeamWiseTimeSummaryLinearChart({
   team,
 }: TeamWiseTimeSummaryLinearProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<TeamWiseTimeSummaryLinearResponse | null>(
     null,
   );
   const theme = useTheme();
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString(
         'backend.baseUrl',
       )}/api/time-saver/getTimeSummary/team`,

--- a/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
@@ -71,7 +71,7 @@ export function TeamWiseTimeSummaryLinearChart({
         setData(dt);
       })
       .catch();
-  }, [configApi, team]);
+  }, [configApi, team, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TeamWiseTimeSummaryLinearComponent/TeamWiseTimeSummaryLinearComponent.tsx
@@ -55,11 +55,12 @@ export function TeamWiseTimeSummaryLinearChart({
   );
   const theme = useTheme();
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString(
-        'backend.baseUrl',
-      )}/api/time-saver/getTimeSummary/team`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/getTimeSummary/team`,
+      )
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
@@ -16,9 +16,8 @@
 import * as React from 'react';
 import { Autocomplete } from '@material-ui/lab';
 import { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { fetchWithCredentials } from '../utils';
 import { TextField } from '@material-ui/core';
 
 interface TemplateChange {
@@ -45,8 +44,9 @@ export default function TemplateAutocomplete({
 
   const [data, setData] = useState<TemplateResponse | null>(null);
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString('backend.baseUrl')}/api/time-saver/templates`,
     )
       .then(response => response.json())

--- a/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
@@ -52,7 +52,7 @@ export default function TemplateAutocomplete({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateAutocompleteComponent/TemplateAutocompleteComponent.tsx
@@ -46,9 +46,10 @@ export default function TemplateAutocomplete({
   const configApi = useApi(configApiRef);
   const fetchApi = useApi(fetchApiRef);
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString('backend.baseUrl')}/api/time-saver/templates`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString('backend.baseUrl')}/api/time-saver/templates`,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
@@ -53,7 +53,7 @@ export default function TemplateTaskAutocomplete({
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();
-  }, [configApi]);
+  }, [configApi, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
@@ -16,9 +16,8 @@
 import * as React from 'react';
 import { Autocomplete } from '@material-ui/lab';
 import { useEffect, useState } from 'react';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import { fetchWithCredentials } from '../utils';
 import { TextField } from '@material-ui/core';
 
 interface TemplateTaskChange {
@@ -45,9 +44,10 @@ export default function TemplateTaskAutocomplete({
 
   const [data, setData] = useState<TemplateTasksResponse | null>(null);
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   useEffect(() => {
-    fetchWithCredentials(
+    fetchApi.fetch(
       `${configApi.getString('backend.baseUrl')}/api/time-saver/templateTasks`,
     )
       .then(response => response.json())

--- a/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateTaskAutocompleteComponent/TemplateTaskAutocompleteComponent.tsx
@@ -47,9 +47,12 @@ export default function TemplateTaskAutocomplete({
   const fetchApi = useApi(fetchApiRef);
 
   useEffect(() => {
-    fetchApi.fetch(
-      `${configApi.getString('backend.baseUrl')}/api/time-saver/templateTasks`,
-    )
+    fetchApi
+      .fetch(
+        `${configApi.getString(
+          'backend.baseUrl',
+        )}/api/time-saver/templateTasks`,
+      )
       .then(response => response.json())
       .then(dt => setData(dt))
       .catch();

--- a/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
@@ -56,7 +56,8 @@ export function DailyTimeSummaryLineChartTemplateWise({
     const url = `${configApi.getString(
       'backend.baseUrl',
     )}/api/time-saver/getDailyTimeSummary/template`;
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
@@ -25,8 +25,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -48,6 +48,7 @@ export function DailyTimeSummaryLineChartTemplateWise({
   template_name,
 }: DailyTimeSummaryLineProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
 
   const [data, setData] = useState<DailyTimeSummaryResponse | null>(null);
   const theme = useTheme();
@@ -55,7 +56,7 @@ export function DailyTimeSummaryLineChartTemplateWise({
     const url = `${configApi.getString(
       'backend.baseUrl',
     )}/api/time-saver/getDailyTimeSummary/template`;
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseDailyTimeLinearComponent/TemplateWiseWiseDailyTimeLinearComponent.tsx
@@ -68,7 +68,7 @@ export function DailyTimeSummaryLineChartTemplateWise({
         setData(dt);
       })
       .catch();
-  }, [configApi, template_name]);
+  }, [configApi, template_name, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
@@ -65,7 +65,7 @@ export function TemplateWiseTimeSummaryLinearChart({
         setData(dt);
       })
       .catch();
-  }, [configApi, template_name]);
+  }, [configApi, template_name, fetchApi]);
 
   if (!data) {
     return <CircularProgress />;

--- a/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
@@ -55,7 +55,8 @@ export function TemplateWiseTimeSummaryLinearChart({
     const url = `${configApi.getString(
       'backend.baseUrl',
     )}/api/time-saver/getTimeSummary/template`;
-    fetchApi.fetch(url)
+    fetchApi
+      .fetch(url)
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
+++ b/plugins/time-saver/src/components/TemplateWiseTimeSummaryLinearComponent/TemplateWiseTimeSummaryLinearComponent.tsx
@@ -24,8 +24,8 @@ import {
   ChartOptions,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { configApiRef, useApi } from '@backstage/core-plugin-api';
-import { fetchWithCredentials, getRandomColor } from '../utils';
+import { configApiRef, fetchApiRef, useApi } from '@backstage/core-plugin-api';
+import { getRandomColor } from '../utils';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import { useTheme } from '@material-ui/core';
 
@@ -47,6 +47,7 @@ export function TemplateWiseTimeSummaryLinearChart({
   template_name,
 }: TemplateWiseTimeSummaryLinearProps): React.ReactElement {
   const configApi = useApi(configApiRef);
+  const fetchApi = useApi(fetchApiRef);
   const [data, setData] =
     useState<TemplateWiseTimeSummaryLinearResponse | null>(null);
   const theme = useTheme();
@@ -54,7 +55,7 @@ export function TemplateWiseTimeSummaryLinearChart({
     const url = `${configApi.getString(
       'backend.baseUrl',
     )}/api/time-saver/getTimeSummary/template`;
-    fetchWithCredentials(url)
+    fetchApi.fetch(url)
       .then(response => response.json())
       .then(dt => {
         dt.stats.sort(

--- a/plugins/time-saver/src/components/utils.ts
+++ b/plugins/time-saver/src/components/utils.ts
@@ -22,4 +22,3 @@ export function getRandomColor() {
   }
   return color;
 }
-

--- a/plugins/time-saver/src/components/utils.ts
+++ b/plugins/time-saver/src/components/utils.ts
@@ -23,12 +23,3 @@ export function getRandomColor() {
   return color;
 }
 
-export async function fetchWithCredentials(
-  url: string | URL,
-  options = {},
-): Promise<Response> {
-  return fetch(url, {
-    ...options,
-    credentials: 'include',
-  });
-}


### PR DESCRIPTION
Adopting new service to service standard from upstream backstage by reading a static token from the app-config and using it against the scaffolder api.

Deprecating fetchWithCredentials with native fetch in favor of fetchApi implementation from @backstage/core-plugin-api to avoid having to retrieve the token manually on the frontend.

#21